### PR TITLE
 Chunk the requests to ClearlyDefined

### DIFF
--- a/pkg/enhance/enhance.go
+++ b/pkg/enhance/enhance.go
@@ -54,7 +54,7 @@ func coordList(s *sbom.Document) []string {
 
 func getDefs(coords []string) (map[string]*cd.Definition, error) {
 	allDefs := make(map[string]*cd.Definition)
-	chunkSize := 100
+	chunkSize := 500
 	for i := 0; i < len(coords); i += chunkSize {
 		end := i + chunkSize
 		if end > len(coords) {

--- a/pkg/enhance/enhance.go
+++ b/pkg/enhance/enhance.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) Jeff Mendoza <jlm@jlm.name>
+// Copyright (c) Gary O'Neall <gary@sourceauditor.com>
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
@@ -12,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -53,7 +55,7 @@ func coordList(s *sbom.Document) []string {
 }
 
 func getDefs(coords []string) (map[string]*cd.Definition, error) {
-	allDefs := make(map[string]*cd.Definition)
+	allDefs := make(map[string]*cd.Definition, len(coords))
 	chunkSize := 500
 	for i := 0; i < len(coords); i += chunkSize {
 		end := i + chunkSize
@@ -64,9 +66,7 @@ func getDefs(coords []string) (map[string]*cd.Definition, error) {
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range defs {
-			allDefs[k] = v
-		}
+		maps.Copy(allDefs, defs)
 	}
 	return allDefs, nil
 }


### PR DESCRIPTION
Prevents a 400 bad request error from the service

Fixes #1 

@jeffmendoza