### PR TITLE
Remove debug println on error status

### DIFF
--- a/pkg/enhance/enhance.go
+++ b/pkg/enhance/enhance.go
@@ -81,7 +81,6 @@ func getDefsFromService(coords []string) (map[string]*cd.Definition, error) {
 		return nil, fmt.Errorf("error querying ClearlyDefined: %w", err)
 	}
 	if rsp.StatusCode != http.StatusOK {
-		fmt.Println(string(cs))
 		return nil, fmt.Errorf("error querying ClearlyDefined: %v", rsp.Status)
 	}
 	body, err := io.ReadAll(rsp.Body)


### PR DESCRIPTION
@jeffmendoza - I accidentally left this in on the last PR.  It will only print on a status error, so probably not much of an issue, but I thought I would clean it up.  If you think it may be useful to keep it, feel free to close this PR.