### PR TITLE
Add ratelimiting.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 require (
 	github.com/guacsec/sw-id-core v0.1.0
 	github.com/protobom/protobom v0.5.0
+	golang.org/x/time v0.10.0
 )
 
 //replace github.com/guacsec/sw-id-core => ../sw-id-core

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/time v0.10.0 h1:3usCWA8tQn0L8+hFJQNgzpWbd89begxN66o1Ojdn5L4=
+golang.org/x/time v0.10.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 //
 // Copyright (c) Jeff Mendoza <jlm@jlm.name>
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 //
 
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -24,7 +26,7 @@ func main() {
 
 	document, format := read(inFile)
 
-	if err := enhance.Do(document); err != nil {
+	if err := enhance.Do(context.Background(), document); err != nil {
 		fmt.Printf("Error enhancing sbom: %v\n", err)
 		os.Exit(1)
 	}

--- a/sbomnotice/main.go
+++ b/sbomnotice/main.go
@@ -1,11 +1,13 @@
 //
 // Copyright (c) Jeff Mendoza <jlm@jlm.name>
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// SPDX-License-Identifier: MIT
 //
 
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -21,7 +23,7 @@ func main() {
 
 	document := read(inFile)
 
-	notice, err := enhance.Notice(document)
+	notice, err := enhance.Notice(context.Background(), document)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Rate limit calls to ClearlyDefined. Both batch definitions and notice are limited to 250/min. Also the library accepts a context now, and the limiter will abort if the context is cancelled. Fix license headers as well. TODO: chunk the calls to the notice endpoint as well.

Fixes #4 