### PR TITLE
feat: introduce min-score parameter as a score threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ Make sure `$GOBIN` is in your path.
 
 Example:
 ```sh
-cdsbom -out enhanced-sbom.json input-sbom.json
+cdsbom -min-score 50 -out enhanced-sbom.json input-sbom.json
 ```
 
 This will read `input-sbom.json` and query ClearlyDefined for License
 information. The License fields in the SBOM will be replaced to use the license
-data returned from ClearlyDefined. A new sbom will be written to
-`enhanced-sbom.json` with the updated fields in the same format as the input
-sbom.
+data returned from ClearlyDefined (with the Clearly Defined effective score greater than or equal to the **min-score**).
+A new sbom will be written to `enhanced-sbom.json` with the updated fields in the same format as the input sbom.
 
 Supported formats are the [same as
 Protobom](https://github.com/protobom/protobom/blob/main/README.md#supported-versions-and-formats).

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 }
 
 // flags sets up and parses flags. Return values are input file and output file
-// respecively.
+// respectively.
 func flags() (string, string, int) {
 	o := flag.String("out", "", "Name of output file, default is <infile>-new.json")
 	s := flag.Int("min-score", 0, "The minimum effective cd score for license confidence (0-100). Default is 0.")

--- a/main.go
+++ b/main.go
@@ -22,11 +22,11 @@ import (
 )
 
 func main() {
-	inFile, outFile := flags()
+	inFile, outFile, minScore := flags()
 
 	document, format := read(inFile)
 
-	if err := enhance.Do(context.Background(), document); err != nil {
+	if err := enhance.Do(context.Background(), document, minScore); err != nil {
 		fmt.Printf("Error enhancing sbom: %v\n", err)
 		os.Exit(1)
 	}
@@ -37,8 +37,9 @@ func main() {
 
 // flags sets up and parses flags. Return values are input file and output file
 // respecively.
-func flags() (string, string) {
+func flags() (string, string, int) {
 	o := flag.String("out", "", "Name of output file, default is <infile>-new.json")
+	s := flag.Int("min-score", 0, "The minimum effective cd score for license confidence (0-100). Default is 0.")
 
 	flag.Usage = func() {
 		fmt.Printf("Usage of %s:\n", os.Args[0])
@@ -66,7 +67,7 @@ func flags() (string, string) {
 		}
 	}
 
-	return i, *o
+	return i, *o, *s
 }
 
 // read reads in the sbom document and also returns the format.


### PR DESCRIPTION
Feature to address issue #16 

+ Introduces the `-min-score` parameter. This can be used to filter out the CD licenses with low score i.e. any CD provided license below this score would not be added to the enhanced SBOM.
+ `min-score` defaults to 0 so that existing functionality is not broken.